### PR TITLE
HIP edits to XX-Response-Time-Windows-for-Witness-Rewarding.md

### DIFF
--- a/XX-Response-Time-Windows-for-Witness-Rewarding.md
+++ b/XX-Response-Time-Windows-for-Witness-Rewarding.md
@@ -1,26 +1,27 @@
 # HIP XX: Response Time Windows for Witness Rewarding
 
-- Author: @disk91, @jmarcelino
+- Author: [@disk91](https://github.com/disk91/), [@jmarcelino](https://github.com/jmarcelino)
 - Start Date: 2023/07/20
 - Category: Economic, Technical
+- Original HIP PR: [#749](https://github.com/helium/HIP/pull/749)
 - Tracking issue:
 - Voting Requirements: veIoT Holders
 
 # Summary 
 
-Currently the Proof-of-Coverage Oracles rewards the 14 first hotspots (eq *default_max_witnesses_per_poc* ) reporting a witness. This rewards the fastest hotspots, incentivizing fiber backhauls and specific hardware models that happen to be able to produce fast signatures. The result is that the same hotspots are selected, making others unviable even if they provide unique and useful coverage for the network. In other words, punishes hotspots for falling short of millisecond optimizations when the LoRaWAN protocol functions to the order of seconds - [see also](#rewarded-hotspots-for-witnesses). 
-A hotspot’s utility in providing LoRaWAN coverage is based on measuring “good enough” response times, not absolute fastest as absolute speeds provides no marginal utility, Uplink does not have a particular time-window, donwlink time windows is up to 2 seconds, Join process up to 6 seconds.
+Currently the Proof-of-Coverage Oracles reward the 14 first hotspots (defined in *default_max_witnesses_per_poc* ) reporting a witness. This rewards the fastest hotspots, incentivizing fiber backhauls and specific hardware models that happen to be able to produce fast signatures. The result is that the same hotspots are selected, making others unviable even if they provide unique and useful coverage for the network. In other words, it punishes hotspots for falling short of millisecond optimizations when the LoRaWAN protocol functions to the order of seconds - [see also](#rewarded-hotspots-for-witnesses). 
+A hotspot’s utility in providing LoRaWAN coverage is based on measuring “good enough” response times, not absolute fastest as absolute speeds provides no marginal utility, the Uplink does not have a particular time-window, the downlink time windows is up to 2 seconds, and the Join process up to 6 seconds.
 
 Since HIP-83, changing the way hotspot are selected, we see an acceleration of [hotspots not participating to PoC anymore](#network-hotspot-loss-acceleration) conducting to network size reduction.
 
 This HIP proposes to evolve the hotspot selection by adding a response time window to eliminate only 
-slow hotspots that fail to meet LoRaWAN-grade timing constraints and push helium hotspots to improve their reponse time, over time, reasonibly. 
+slow hotspots that fail to meet LoRaWAN-grade timing constraints and push helium hotspots to improve their reponse time, over time, reasonably. 
 
 # Motivation
 
 The LoRaWAN network has some timing constraints to be considered, these ones are related to the JOIN mechanism 
-and ACK/Downlink mechanism. JOIN requires a full loop within 5 seconds, up to 6. ACK/Downlink requires a full loop in 1 
-second for RX1 window, up to 2 seconds for RX2 windows. Out of this time frame, the response will be ignored by the devices.  [Appendix](#packet-processing-and-lorawan-time-constraints) gives the consequence of these constraints on the expected hotspot response time.
+and ACK/Downlink mechanism. JOIN requires a full loop within 5 seconds, up to 6 seconds. ACK/Downlink requires a full loop in 1 
+second for RX1 window, up to 2 seconds for RX2 windows. Out of this time frame, the response will be ignored by the sensor devices.  [Appendix](#packet-processing-and-lorawan-time-constraints) gives the consequence of these constraints on the expected hotspot response time.
 
 LoRaWAN is a question of seconds ($`10^0s`$ to $`10^{-1}s`$), not a question of microseconds ($`10^{-6}s`$), this is why creating a competition between hotspots and network connectivity at a millisecond ($`10^{-3}s`$) scale is not achieving any network goal.
 
@@ -30,87 +31,95 @@ sometimes rely on higher latency connectivity (4G/5G, Home Plug, Satellites) whi
 and are unfairly impacted by the current selection algorithm as they still operate within LoRaWAN timing specifications. 
 See [appendix](#highly-valuable-coverage) about highly valuable coverage.
 
-Hotspot out of the city centers will get a slower Internet response time from the one in the city center, 
+Hotspots located out of city centers will get a slower Internet response time from the one in the city center, 
 even with fast Internet access, due to some extra network hops or downgraded connectivity technology like xDSL.
 See [Appendix](#suburb-valuable-coverage) about suburb valuable coverage.
 
-Hotspot with the worst locations, indoor, in the city center, gets the best response time experience 
+Hotspot with the worst locations, indoor, in the city center, can get the best response time experience 
 with direct fiber connectivity.
 
 We have seen that depending on the hardware of the hotspot, the Witness processing time is largely dependent 
-on the packet signature as described in the [appendix](#ecc-signature-impact). As the signature is delegated to an hardware 
-ECC chip for most of the deployed hotspot, the processing time depends on the [hardware solution](#mcu-performance-impact) soldered. 
+on the packet signature as described in the [appendix](#ecc-signature-impact). As the signature is delegated to the hardware 
+ECC chip for most of the deployed hotspots, the processing time depends on the [hardware solution](#mcu-performance-impact) soldered in. 
 Even if firmware can be improved, the current solution disqualifies certain hardware whatever is the hotspot owner's efforts. 
 
-More generally speaking, it disqualifies lower-end hardware like light-hotspots based on micro-controllers as, by definition, their capacity to process the same thing than an hotspot based on CPU [is lower](#mcu-performance-impact). This is nonsense as these hardware have a better fit for stability, long-life, energy saving, lower cost, and should be privileged long term.
+More generally speaking, it disqualifies lower-end hardware like light-hotspots based on micro-controllers as, by definition, their capacity to process the same thing than an hotspot based on CPU [is lower](#mcu-performance-impact). This is nonsense as this hardware has a better fit for stability, long-life, energy saving, lower cost, and should be privileged long term.
 
 The Peoples Network must be accessible to anyone and not be a competition of miliseconds optimization limited to a 
 small group of experts.
 
 The witness response time is not representative of the data packet processing. Witness response time does not have any 
 constraint of time. Witnesses are processed by Oracle, and response time depends on the Oracle localization, 
-associated with the network path to reach that Oracle. It totally differ from the LNS network path.
+associated with the network path to reach that Oracle. It is totally different from the LNS network path taken by sensors.
 Response time can differ from a Witness to another Witness, the absolute response time is not a good way to measure a performance responding to the LoRaWAN timing constraints. The [Witness process](#witness-processing-waterfall) and the [Packet process](#packet-processing-waterfall) are detailed in the respective appendixes.
 
 As for a given witness, the Hotspots from a similar area will report it to the same Oracle, we can consider a response 
 time window starting from the first witness received by the Oracle as a viable solution to eliminate the variable offset 
-timing and to eliminate hotspot that are really slower and can cause a problem for data processing.
+timing and to eliminate those hotspots that are really slower and can cause a problem for data processing.
+
+# Stakeholders
+
+The earnings of All hotspot owners could be can be affected by this HIP. 
+It positively benefits hotspot owners negatively affected by HIP-83 who due to configuration or vendor are the slowest to respond and received less witness rewards.
+It negatively affects hotspot owners positively affected by HIP-83 who due to being the fastest to respond always got selected for witness rewards.
+It positivly affects hotspot vendors designs that were slower than other hotspot vendors designs but still within LoRaWAN specifications.
+Nova labs are the entity requested to implement the changes in the HIP.
 
 # Rationale and Alternatives
 
 This HIP proposes to select a valid witness from the ones arriving in a time window of MAX_WITNESS_WAIT_WINDOW_MS starting 
 from the first received witness by the Oracle. 
 
-The MAX_WITNESS_WAIT_WINDOWS_MS parameter will be initially set to 200ms, accordingly to the calculation described in [appendix](#packet-processing-waterfall). 
+The MAX_WITNESS_WAIT_WINDOWS_MS parameter will be initially set to 200ms (0.2 seconds), accordingly to the calculation described in [appendix](#packet-processing-waterfall). 
 It could be later adjusted from 100ms to 300ms by Helium Foundation to optimize the network quality without a need for a new
-vote. The purpose of this adjustement is to push hardware manufacturers to optimize their solutions in a scheduled way. The initial 200ms take into consideration the ECC signature and radio backhaul normal impact vs DiY in the LoRaWan constraints. 
+vote. The purpose of this adjustment is to push hardware manufacturers to optimize their solutions in a scheduled way. The initial 200ms take into consideration the ECC signature and radio backhaul normal impact vs DiY in the LoRaWan constraints. 
 
-When less than **default_max_witnesses_per_poc** Witnesses have been received within the MAX_WITNESS_WAIT_WINDOWS_MS, the Oracle accepts Witnesses up to EXTENDED_WITNESS_WAIT_WINDOWS_MS, fixed at 500ms, the acceptable wait time for RX1 windows for regional traffic. This will allow slower hotspot to be accepted in the low density area when in high density the constraint is stronger. The current situation, with HIP83, is accepting witness without limit of time in a such case, even if the time makes no LoRaWAN downlink & join possible.
+When less than **default_max_witnesses_per_poc** Witnesses (Currently 14) have been received within the MAX_WITNESS_WAIT_WINDOWS_MS, the Oracle accepts Witnesses up to EXTENDED_WITNESS_WAIT_WINDOWS_MS, fixed at 500ms, the acceptable wait time for RX1 windows for regional traffic. This will allow slower responding hotspots to be accepted in the low density areas when in high density the constraint is stronger. The current situation, with HIP-83, is accepting witness without limit of time in a such case, even if the time makes no LoRaWAN downlink & join possible.
 
 This means: 
 1. Different hotspots receive a beacon and send the witness information to the related Oracle
 2. The Oracle receives the first witness notification and opens a witness reception window for MAX_WITNESS_WAIT_WINDOWS_MS
-milliseconds. Witness is marked valid.
-3. The Oracle receives the next witnesses during the MAX_WITNESS_WAIT_WINDOWS_MS ms and mark them valid.
-4. When **default_max_witnesses_per_poc** or more have been received, it marks the other as invalid
+milliseconds. Witness is marked Valid.
+3. The Oracle receives the next witnesses during the MAX_WITNESS_WAIT_WINDOWS_MS ms and mark them Valid.
+4. When **default_max_witnesses_per_poc** or more have been received, it marks the other as Invalid
 5. When MAX_WITNESS_WAIT_WINDOWS_MS is over and less than **default_max_witnesses_per_poc** received, Oracle marks the first received as selected and waits until **default_max_witnesses_per_poc** or EXTENDED_WITNESS_WAIT_WINDOWS_MS, mark them as valid, then the others invalid.
-7. The Oracle selects all the **selected** witnesses and complete to **default_max_witnesses_per_poc** by selected ramdomly some of the one marked as valid.
+7. The Oracle selects all the **selected** witnesses and allocates rewards to the number of hotspots defined in **default_max_witnesses_per_poc** by selecting ramdomly from the ones marked as valid.
 
-### Exemple 1
+### Example 1
 
 8 witnesses received:
-- 4 within MAX_WITNESS_WAIT_WINDOWS_MS
-- 3 within EXTENDED_WITNESS_WAIT_WINDOWS_MS
-- 1 out of WINDOWS
+- 4 within MAX_WITNESS_WAIT_WINDOWS_MS 200ms
+- 3 within EXTENDED_WITNESS_WAIT_WINDOWS_MS 200-500ms
+- 1 outside EXTENDED_WITNESS_WAIT_WINDOWS_MS 500ms
 
-The 4 firsts are marked as SELECTED, the 3 next are marked as VALID, the last one is marked as INVALID. Oracle rewards all the one marked as SELECTED, it can select 10 more randomly as part of the ones marked as VALID, so it reward all of them. The last one is not rewarded. Assuming **default_max_witnesses_per_poc** is 14
+The first 4 are marked as SELECTED, the 3 next are marked as VALID, the last one is marked as INVALID. Oracle rewards all the one marked as SELECTED, it can select 10 more randomly as part of the ones marked as VALID, so it reward all of them. The last one is not rewarded. Assuming **default_max_witnesses_per_poc** is 14
 
-### Exemple 2
+### Example 2
 25 witnesses received:
-- 20 within MAX_WITNESS_WAIT_WINDOWS_MS
-- 4 within EXTENDED_WITNESS_WAIT_WINDOWS_MS
-- 1 out of WINDOWS
+- 20 within MAX_WITNESS_WAIT_WINDOWS_MS 200ms
+- 4 within EXTENDED_WITNESS_WAIT_WINDOWS_MS 200-500ms
+- 1 outside EXTENDED_WITNESS_WAIT_WINDOWS_MS 500ms
 
 Only the first 20 within MAX_WITNESS_WAIT_WINDOWS_MS will be selected and marked as VALID, all the others are INVALID and won't be part of the reward calculation. The Oracle will randomly select 14 of the 20 VALID witness and reward them. Assuming **default_max_witnesses_per_poc** is 14
 
-### Exemple 3
+### Example 3
 25 witnesses received:
-- 10 within MAX_WITNESS_WAIT_WINDOWS_MS
-- 8 within EXTENDED_WITNESS_WAIT_WINDOWS_MS
-- 7 out of WINDOWS
+- 10 within MAX_WITNESS_WAIT_WINDOWS_MS 200ms
+- 8 within EXTENDED_WITNESS_WAIT_WINDOWS_MS 200-500ms
+- 7 outside EXTENDED_WITNESS_WAIT_WINDOWS_MS 500ms
 
-The 10 firsts are marked as SELECTED, the next 8 are marked as VALID, the 7 others are marked as INVALID. Oracle will reward all the SELECTED, then is will randomly choose 6 (14-8) of the 8 witnesses marked as VALID and reward them. Assuming **default_max_witnesses_per_poc** is 14
+The first 10 are marked as SELECTED, the next 8 are marked as VALID, the 7 others are marked as INVALID. Oracle will reward all the SELECTED, then will randomly choose 6 (14-8) of the 8 witnesses marked as VALID and reward them. Assuming **default_max_witnesses_per_poc** is 14
 
 ** Alternate Proposal **
 
 This HIP proposes to select all witness arriving in a time window of MAX_WITNESS_WAIT_WINDOW_MS starting 
 from the first received witness by the Oracle. 
 
-The MAX_WITNESS_WAIT_WINDOWS_MS parameter will be initially set to 200ms, accordingly to the calculation described in [appendix](#packet-processing-waterfall).  
+The MAX_WITNESS_WAIT_WINDOWS_MS parameter will be initially set to 200ms (0.2 seconds), accordingly to the calculation described in [appendix](#packet-processing-waterfall).  
 It could be later adjusted from 100ms to 300ms by Helium Foundation to optimize the network quality without a need for a new
-vote. The purpose of this adjustement is to push hardware manufacturers to optimize their solutions in a scheduled way. The initial 200ms take into consideration the ECC signature and radio backhaul normal impact vs DiY in the LoRaWan constraints. 
+vote. The purpose of this adjustment is to push hardware manufacturers to optimize their solutions in a scheduled way. The initial 200ms take into consideration the ECC signature and radio backhaul normal impact vs DiY in the LoRaWan constraints. 
 
-When less than 5 Witnesses have been received within the MAX_WITNESS_WAIT_WINDOWS_MS, the Oracle accepts Witnesses, with a maximum ot 5 total, up to EXTENDED_WITNESS_WAIT_WINDOWS_MS, fixed at 500ms, the acceptable wait time for RX1 windows for regional traffic. This will allow slower hotspot to be accepted in the low density area when in high density the constraint is stronger. This allows to have sat backhaul in low density areas. The current situation, with HIP83, is accepting witness without limit of time in a such case, even if the time makes no LoRaWAN downlink & join possible.
+When less than 5 Witnesses have been received within the MAX_WITNESS_WAIT_WINDOWS_MS, the Oracle accepts Witnesses, with a maximum ot 5 total, up to EXTENDED_WITNESS_WAIT_WINDOWS_MS, fixed at 500ms, the acceptable wait time for RX1 windows for regional traffic. This will allow slower hotspots to be accepted in the low density area when in high density the constraint is stronger. This allows to have satellite backhaul in low density areas. The current situation, with HIP-83, is accepting witness without limit of time in a such case, even if the time makes no LoRaWAN downlink & join possible.
 
 This means: 
 1. Different hotspots receive a beacon and send the witness information to the related Oracle
@@ -121,46 +130,49 @@ milliseconds. Witness is marked SELECTED.
 5. When MAX_WITNESS_WAIT_WINDOWS_MS is over and less than 5 received, Oracle marks the next SELECTED until EXTENDED_WITNESS_WAIT_WINDOWS_MS with a maximum of 5 witnesses total, next are marked INVALID.
 7. The Oracle selects all the **SELECTED** witnesses to be rewarded.
 
-### Exemple 1
+### Example 1
 
 8 witnesses received:
-- 4 within MAX_WITNESS_WAIT_WINDOWS_MS
-- 3 within EXTENDED_WITNESS_WAIT_WINDOWS_MS
-- 1 out of WINDOWS
+- 4 within MAX_WITNESS_WAIT_WINDOWS_MS 200ms
+- 3 within EXTENDED_WITNESS_WAIT_WINDOWS_MS 200-500ms
+- 1 outside EXTENDED_WITNESS_WAIT_WINDOWS_MS 500ms
 
-The 4 firsts are marked as SELECTED, the first 1 next is marked as SELECTED, the 2 two next within EXTENDED_WITNESS_WAIT_WINDOWS_MS and the one out of WINDOWS are marked as INVALID. Oracle rewards all the one marked as SELECTED. The last 3 are not rewarded.
+The first 4 are marked as SELECTED, the first 1 of the next 3 is marked as SELECTED, the 2 next of 3 within EXTENDED_WITNESS_WAIT_WINDOWS_MS and the one out of WINDOWS are marked as INVALID. Oracle rewards all the one marked as SELECTED. The last 3 are not rewarded.
 
-### Exemple 2
+### Example 2
 25 witnesses received:
-- 20 within MAX_WITNESS_WAIT_WINDOWS_MS
-- 4 within EXTENDED_WITNESS_WAIT_WINDOWS_MS
-- 1 out of WINDOWS
+- 20 within MAX_WITNESS_WAIT_WINDOWS_MS 200ms
+- 4 within EXTENDED_WITNESS_WAIT_WINDOWS_MS 200-500ms
+- 1 outside EXTENDED_WITNESS_WAIT_WINDOWS_MS 500ms
 
 Only the first 20 within MAX_WITNESS_WAIT_WINDOWS_MS will be selected and marked as SELECTED, all the others are INVALID and won't be part of the reward calculation. The Oracle will reward all the SELECTED witnesses.
 
-### Exemple 3
+### Example 3
 25 witnesses received:
-- 10 within MAX_WITNESS_WAIT_WINDOWS_MS
-- 8 within EXTENDED_WITNESS_WAIT_WINDOWS_MS
-- 7 out of WINDOWS
+- 10 within MAX_WITNESS_WAIT_WINDOWS_MS 200ms
+- 8 within EXTENDED_WITNESS_WAIT_WINDOWS_MS 200-500ms
+- 7 outside EXTENDED_WITNESS_WAIT_WINDOWS_MS 500ms
 
-The 10 firsts are marked as SELECTED, the next 8 are marked as INVALID, the 7 others are marked as INVALID. Oracle will reward all the SELECTED and reward them.
+The first 10 are marked as SELECTED, the next 8 are marked as INVALID, the 7 others are marked as INVALID. Oracle will reward all the SELECTED and reward them.
 
 # Unresolved Questions
 
-- Packet processing is currently involving signature from ECC fro every packet, this is time costly and not mandatory.
+- Packet processing is currently involving signature from ECC for every packet, this is time costly and not mandatory.
 Some discussions are already opened to move this with a software signature from an ECC derivated key negotiated with Helium
 Packet Router for a given period of time.
 
 - Witness could be selected also in regard of their location. For exemple we could get a priority on the witnesses comming from the longest distance to offer an advantage to the hotpost offering the larger coverage.
 
+- There could be some hotspot designs or configurations that always respond over 500ms, these would never be rewarded. 
+
 # Deployment Impact
 
-Oracle PoC rewarding code needs to be modified to take this into consideration. Deployment is global, Hotspots are not impacted. The Oracle PoC code update will impact the Nova team, no code is proposed by the Author of the HIP.
+Oracle PoC rewarding code needs to be modified to take this into consideration. Deployment is global, Hotspots are not impacted. 
+The Oracle PoC code update will impact the Nova team for deployment, the Author of this HIP is not attaching any code..
 
 # Success Metrics
 
-- The distribution of rewards is not any more a function of the hotspot manufacturer
+- The distribution of rewards isno longer a function of the hotspot manufacturer design
 - Hotpots with large coverage get balanced rewards
 - The decrease of active hostots is slowing down
 - The average response time to witness is improved over time
@@ -170,29 +182,29 @@ Oracle PoC rewarding code needs to be modified to take this into consideration. 
 ## Highly Valuable Coverage
 
 Some of the hotspot have a really large coverage by being installed in really good / high location. These hotspots, due to the 
-geographical location and the height are covering wide zone, larger than the city. That way, they are offering a uniq coverage. The following picture is illustrating this: the blue area is representing the coverage offered by this sigle hotspot, the orange 
+geographical location and the height are covering a wide zone, larger than a city. That way, they are offering a unique coverage. The following picture is illustrating this: the blue area is representing the coverage offered by this single hotspot, the orange 
 represent the city coverage provided by the mass of the other hotspot in the same area. All these hotspots are in competition for the same witness.
 
 ![Highly valuable coverage illustration](XX-response-time-windows-for-witness-rewarding/valuable-coverage.png)
 
-This illustration is based on a real exemple, but is a general illustration for hotspot placed on cell-towers and high elevation point. The hotspot used in the illustration as model is Attractive-Olive-Cybord, located in Clermont-Ferrand, France. This hotspot is deployed on high elevation point. Coverage can be seen on mappers.helium.com, with 80km coverage from North to South.
+This illustration is based on a real example, but is a general illustration for hotspot placed on cell-towers and high elevation point. The hotspot used in the illustration as model is Attractive-Olive-Cyborg, located in Clermont-Ferrand, France. This hotspot is deployed on high elevation point. Coverage can be seen on [mappers.helium.com](https://mappers.helium.com/uplinks/hex/891f96a85b3ffff), with 80km coverage from North to South.
 
-In term of coverage comparision, 60km hotspot provides 36x a 10km hotspot in area coverage. It provides about 3600x coverage compared to a indoor, city center located hotspot.
+In term of coverage comparision, a 60km reach hotspot provides 36x the area coverage a 10km reach hotspot can provide. It provides about 3600x coverage compared to a indoor, city center located hotspot.
 
 This HIP does not propose to give these hotspots any advantages, the existing POC mechanisms already manage this. This HIP attempts to remove the penalty these important hotspots are currently suffering due to HIP-83.
 
 ## Suburb Valuable Coverage
 
-The hotspots located in suburb and above, in blue in the illustration, are expending the network coverage with uniq 
+The hotspots located in suburb and above, in blue in the illustration, are expending the network coverage with unique 
 coverage zone and are in competition with the hotspot inside the city. 
 
 ![Suburb illustration](XX-response-time-windows-for-witness-rewarding/suburb-coverage.png)
 
-Helium network development can be associated to a genetic algorithm growing from an already covered place. These Hotspots also making the link with hotspots out of the city and suburb. They are offering a chance, with their beacon, to isolated hotspot out of the city to participate to PoC.
+Helium network development can be associated to a genetic algorithm growing from an already covered place. These Hotspots also making the link with hotspots out of the city and suburb. They are offering a chance, with their beacon, to isolated hotspots out of the city to participate with PoC.
 
-These hotspots does not get benefit of the fastest Internet connection as their fiber connectivity will pass through the city center to reach the main Internet highways. For most of them the fiber connectivity will not be available and they are going to rely on xDSL connectivity before reaching the ISPs fiber Internet backhall.
+These hotspots do not get benefit of the fastest Internet connection as their fiber connectivity will pass through the city center to reach the main Internet highways. For most of them the fiber connectivity will not be available and they are going to rely on xDSL connectivity before reaching the ISPs fiber Internet backhall.
 
-These hotspots are participating to PoC with the city center hotspots without getting benefit of the fastest Internet connection they have more chance to never been or rarely selected.
+As these hotspots are participating in PoC with the city center hotspots without getting benefit of the fastest Internet connection, then the chance is they have never been or rarely selected for witness rewards.
 
 This HIP does not propose to give these hotspots any advantages, the existing POC mechanisms already manage this. This HIP attempts to remove the penalty these important hotspots are currently suffering due to HIP-83.
 
@@ -204,13 +216,13 @@ decided by the LNS after the HPR. This time limit for the LNS is a LNS setup and
 
 LoRaWAN time constraints are the following:
 - UPLINK first copy arrival has no time constraint, next copies are withing the defined LNS deduplication time windows.
-- JOIN REQUEST needs to be responded within 5s for RX1 (same frequency, standard power) or 6s for RX2 (other frequency, potentially higher power). LNS decides of the selection between RX1 and RX2 dynamically, according to the time available.
-- DOWNLINK REQUEST / ACK needs to be responded within 1s for RX1 (same frequency, standard power) or 2s for RX2 (other frequency, potentially higher power). LNS decides of the selection between RX1 and RX2 dynamically, according to the time available.
+- JOIN REQUEST needs to be responded within 5 seconds for RX1 (same frequency, standard power) or 6 seconds for RX2 (other frequency, potentially higher power). LNS decides of the selection between RX1 and RX2 dynamically, according to the time available.
+- DOWNLINK REQUEST / ACK needs to be responded within 1 seconds for RX1 (same frequency, standard power) or 2 seconds for RX2 (other frequency, potentially higher power). LNS decides of the selection between RX1 and RX2 dynamically, according to the time available.
 
 There is no reasons to prefer RX1 vs RX2, most of the implementations try to reach RX1 first, but RX2 provides different advantages, in particular in Europe where the duty cycle on RX2 is better and the higher power makes more chance to reach the device. It also reduce the limited bandwidth usage on the 8 available channels and the risk of collision on these busy channels. Device power impact can be considered higher on RX2 but with a lower risk of collision and reception loss, practically speaking, this assumption is not always true. Selection between RX1 / RX2 is not a question in regard of this HIP. This is informative to
 understand that nothing bad in using one vs the other, both have advantages.
 
-Basically, only the DOWNLINK REQ / ACK creates generate a time constraint at the time scale discussed in this HIP. This time constraints is to make sure that the order to send the ACK or the DOWNLINK transfer order comes to the desired Hotspot before the RX2 windows.
+Basically, only the DOWNLINK REQ / ACK creates generate a time constraint at the time scale discussed in this HIP. This time constraint is to make sure that the order to send the ACK or the DOWNLINK transfer order comes to the desired Hotspot before the RX2 windows.
 
 In this constraint of time, we need to execute the [full packet processing steps](#packet-processing-waterfall).
 
@@ -258,7 +270,7 @@ The following graphics is diplaying the Loss that day (Y axis) over days (X axis
 
 ### Rewarded Hotspots for Witnesses
 
-The following [Helium Geek](https://heliumgeek.com/stats/epoch/iot) stats displays the number of different hotspots rewarded for witnessing and beaconning. You can notice that since HIP 83 launch we had a break in the witness participation by 10.000 hotspots. This means witnesses rewards goes to less hotspots, even if all participating to beaconning. 10.000 of the hotspot are out of most for the reward distribution, to the benefit of the others.
+The following [Helium Geek](https://heliumgeek.com/stats/epoch/iot) stats displays the number of different hotspots rewarded for witnessing and beaconing. You can notice that since HIP 83 launch we had a break in the witness participation by 10,000 hotspots. This means the witnesses rewards goes to less hotspots, even if all are participating to witness beaconing. 10,000 of the hotspot are out of most for the reward distribution, to the benefit of the others.
 
 ## MCU performance impact
 
@@ -332,7 +344,7 @@ The following waterfall represent the different steps in the witness processing,
 ![Witness Processing Waterfall](XX-response-time-windows-for-witness-rewarding/witness-waterfall-1.png)
 
 - Witness processing is the time to execute the gateway-rs code (out of ECC signature), I don't have reference of time and assume it should be around 10ms, any better data is welcome. The variability comes from the different hardware performace for running the same code, we have seen previously a ratio of 3x in term of cpu frequency, associable to performance.
-- ECC signature, as seen previsouly is a factor of magnitude of 4x between no ECC signature and worst ECC implementation.
+- ECC signature, as seen previously is a factor of magnitude of 4x between no ECC signature and worst ECC implementation.
 - The Witness is then reported to iotpoc server, this architecture is zone distributed, so we can assume all the hotspot reporting the Witness will report to the same server within their zone. The time to reach http://mainnet-pociot.helium.io:8080 can be checked with https://check-host.net/ in TCP Port check. The response time vary from 20 to 100ms including network latency natural variability. On top of this we can add an extra variable time related to the use of 4G (50-100ms) or xDSL (30-50ms).
 - Then the iotpoc server reports the witnesses to the Oracle to verify the PoC and compute the rewarding. The time depends on the Oracle location compared to iotpoc server. This is the same network path for all packets. The network natural network latency we have between packets (measurable with ping command, max - min) have an order of magnitude of 10-50ms (about 20%).
 


### PR DESCRIPTION
Added stakeholders section - please feel free to edit. Done some spelling and grammar corrections.
And suggested edits to improve understanding of timings


Alternate Proposal description reads to me that only a max of 5 will ever get rewarded Does it need an extra line saying how many will be selected if they respond in less than MAX_WITNESS_WAIT_WINDOWS_MS?

Alternate example 2
Has 20 rewarded

Does this mean you are defining default_max_witnesses_per_poc as 20? Or will all responding within MAX_WITNESS_WAIT_WINDOWS_MS get rewarded? In which case default_max_witnesses_per_poc needs setting at 256 or 64K